### PR TITLE
Adaptations for python3:

### DIFF
--- a/template/src/__SHORTNAME__/__init__.py
+++ b/template/src/__SHORTNAME__/__init__.py
@@ -1,5 +1,5 @@
 import logging.config
-from daemon import Daemon
+from .daemon import Daemon
 
 import sys
 import time
@@ -7,6 +7,7 @@ import signal
 import logging
 import argparse
 import traceback
+import configparser
 
 from logging.handlers import SysLogHandler
 
@@ -75,7 +76,10 @@ def reload_config():
     """reload configuration"""
     ##
     ##TODO: INSERT CODE TO LOAD YOUR CONFIGURATION HERE, eg. :  ##
-    #newconfig=ConfigParser.ConfigParser()
+    #if sys.version_info[0] == 2:
+    #  newconfig=ConfigParser.ConfigParser()
+    #else:
+    #  newconfig=configparser.ConfigParser()
     #newconfig.readfp(open(CONFIGFILE))
 
     #dconfdir=os.path.join(os.path.dirname(CONFIGFILE),'conf.d')

--- a/template/src/__SHORTNAME__/__init__.py
+++ b/template/src/__SHORTNAME__/__init__.py
@@ -7,7 +7,10 @@ import signal
 import logging
 import argparse
 import traceback
-import configparser
+if sys.version_info[0] == 2:
+  import ConfigParser as CP
+else:
+  import configparser as CP
 
 from logging.handlers import SysLogHandler
 
@@ -76,10 +79,7 @@ def reload_config():
     """reload configuration"""
     ##
     ##TODO: INSERT CODE TO LOAD YOUR CONFIGURATION HERE, eg. :  ##
-    #if sys.version_info[0] == 2:
-    #  newconfig=ConfigParser.ConfigParser()
-    #else:
-    #  newconfig=configparser.ConfigParser()
+    #newconfig=CP.ConfigParser()
     #newconfig.readfp(open(CONFIGFILE))
 
     #dconfdir=os.path.join(os.path.dirname(CONFIGFILE),'conf.d')

--- a/template/src/__SHORTNAME__/daemon.py
+++ b/template/src/__SHORTNAME__/daemon.py
@@ -21,7 +21,8 @@ class Daemon(object):
         if pid == None:
             pid = os.getpid()
         atexit.register(self.del_pid)
-        pidfd=os.open(self.pidfile, os.O_WRONLY|os.O_CREAT, 0644)
+        pidfd=os.open(self.pidfile, os.O_WRONLY|os.O_CREAT)
+        os.chmod(self.pidfile,stat.S_IRUSR|stat.S_IWUSR|stat.S_IRGRP|stat.S_IROTH)
         os.write(pidfd, "%s\n" % pid)
         os.close(pidfd)
 
@@ -33,15 +34,15 @@ class Daemon(object):
 
         try:
             pid = os.fork()
-        except OSError, e:
-            raise Exception, "%s [%d]" % (e.strerror, e.errno)
+        except OSError as e:
+            raise Exception("%s [%d]" % (e.strerror, e.errno))
 
         if (pid == 0):
             os.setsid()
             try:
                 pid = os.fork()    # Fork a second child.
-            except OSError, e:
-                raise Exception, "%s [%d]" % (e.strerror, e.errno)
+            except OSError as e:
+                raise Exception("%s [%d]" % (e.strerror, e.errno))
 
             if (pid == 0):    # The second child.
                 os.chdir('/')
@@ -74,7 +75,7 @@ class Daemon(object):
         if self.pidfile!=None:
             try:
                 self.write_pid()
-            except Exception,e:
+            except Exception as e:
                 sys.stderr.write("Could not write pid %s: %s"%(self.pidfile,str(e)))
         return(0)
 


### PR DESCRIPTION
- replace exception handling like "except Exception,e" with "except Exception as e" in daemon.py
- replace exception handling like "raise Exception, "<str>" with "raise Exception(<str>)" in daemon.py
- in __init__.py change the comment regarding ConfigParser. Add a condition to use module name "ConfigParser" for python 2 and "configparser" otherwise